### PR TITLE
Download attachments by Content-ID

### DIFF
--- a/Documentation/CLI.md
+++ b/Documentation/CLI.md
@@ -47,7 +47,8 @@ post fetch 12199 --server gmail --mailbox Archive   # Specific server + mailbox
 ```bash
 post attachment 12199                                # Download first attachment
 post attachment 12199 --filename "invoice.pdf"       # Download specific file
-post attachment 12199 --out ./downloads              # Custom output directory
+post attachment 12199 --cid "image-content-id"       # Download inline CID asset
+post attachment 12199 --output ./downloads           # Custom output directory
 ```
 
 ### Searching

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ post fetch 12199 --server work
 post fetch 12198,12199 --eml --out ./backup
 post search --from "amazon" --since 2025-01-01
 post move 12345 Archive
-post attachment 12199 --out ./downloads
+post attachment 12199 --output ./downloads
+post attachment 12199 --cid "image-content-id"
 post draft --to colleague@example.com --subject "Update" --body email.md
 ```
 

--- a/Sources/PostServer/PostServer.swift
+++ b/Sources/PostServer/PostServer.swift
@@ -14,6 +14,7 @@ public enum PostServerError: Error, LocalizedError, Sendable {
     case messageNotFound(uid: Int, mailbox: String)
     case noAttachments(uid: Int)
     case attachmentNotFound(filename: String, uid: Int)
+    case attachmentContentIdNotFound(contentId: String, uid: Int)
     case attachmentDataMissing(filename: String)
     case noIdleEnabledServers
     case emptyBody(uid: Int)
@@ -47,6 +48,8 @@ public enum PostServerError: Error, LocalizedError, Sendable {
             return "Message UID \(uid) has no attachments."
         case .attachmentNotFound(let filename, let uid):
             return "Attachment '\(filename)' not found in message UID \(uid)."
+        case .attachmentContentIdNotFound(let contentId, let uid):
+            return "Attachment with Content-ID '\(contentId)' not found in message UID \(uid)."
         case .attachmentDataMissing(let filename):
             return "Could not decode attachment data for '\(filename)'."
         case .noIdleEnabledServers:
@@ -719,10 +722,11 @@ public actor PostServer {
     /// - Parameter serverId: The server identifier
     /// - Parameter uid: The message UID
     /// - Parameter filename: Attachment filename to download (optional, downloads first if omitted)
+    /// - Parameter cid: Content-ID of an inline attachment to download
     /// - Parameter mailbox: Mailbox name (default: "INBOX")
     /// - Returns: Base64-encoded attachment data with metadata
     @MCPTool
-    public func downloadAttachment(serverId: String, uid: Int, filename: String? = nil, mailbox: String = "INBOX") async throws -> AttachmentData {
+    public func downloadAttachment(serverId: String, uid: Int, filename: String? = nil, cid: String? = nil, mailbox: String = "INBOX") async throws -> AttachmentData {
         guard (1...Int(UInt32.max)).contains(uid) else {
             throw PostServerError.invalidUID(uid)
         }
@@ -732,6 +736,27 @@ public actor PostServer {
             let set = MessageIdentifierSet<UID>(UID(UInt32(uid)))
 
             for try await message in server.fetchMessages(using: set) {
+                if let cid {
+                    let normalizedCID = Self.normalizedContentID(cid)
+                    guard let match = message.cids.first(where: { part in
+                        guard let contentId = part.contentId else { return false }
+                        return Self.normalizedContentID(contentId) == normalizedCID
+                    }) else {
+                        throw PostServerError.attachmentContentIdNotFound(contentId: cid, uid: uid)
+                    }
+
+                    guard let data = match.decodedData() ?? match.data else {
+                        throw PostServerError.attachmentDataMissing(filename: match.suggestedFilename)
+                    }
+
+                    return AttachmentData(
+                        filename: match.filename ?? match.suggestedFilename,
+                        contentType: match.contentType,
+                        data: data.base64EncodedString(),
+                        size: data.count
+                    )
+                }
+
                 let attachments = message.attachments
 
                 guard !attachments.isEmpty else {
@@ -764,6 +789,20 @@ public actor PostServer {
 
             throw PostServerError.messageNotFound(uid: uid, mailbox: mailbox)
         }
+    }
+
+    internal nonisolated static func normalizedContentID(_ contentID: String) -> String {
+        var value = contentID.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if value.lowercased().hasPrefix("cid:") {
+            value = String(value.dropFirst(4)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if value.hasPrefix("<"), value.hasSuffix(">"), value.count >= 2 {
+            value = String(value.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return (value.removingPercentEncoding ?? value).lowercased()
     }
 
     /// Downloads the raw RFC 822 source of a single message as binary data.

--- a/Sources/post/Commands/Attachment.swift
+++ b/Sources/post/Commands/Attachment.swift
@@ -12,6 +12,9 @@ extension PostCLI {
         @Option(name: .long, help: "Attachment filename (downloads first if omitted)")
         var filename: String?
 
+        @Option(name: .long, help: "Content-ID of an inline attachment to download")
+        var cid: String?
+
         @Option(name: .long, help: "Server identifier")
         var server: String?
 
@@ -21,10 +24,16 @@ extension PostCLI {
         @Option(name: .long, help: "Output path — directory or filename (default: current directory)")
         var output: String = "."
 
+        func validate() throws {
+            if filename != nil && cid != nil {
+                throw ValidationError("Use either --filename or --cid, not both.")
+            }
+        }
+
         func run() async throws {
             try await PostProxy.withClient { client in
                 let serverId = try await server.resolveServerID(using: client)
-                let attachment = try await client.downloadAttachment(serverId: serverId, uid: uid, filename: filename, mailbox: mailbox)
+                let attachment = try await client.downloadAttachment(serverId: serverId, uid: uid, filename: filename, cid: cid, mailbox: mailbox)
 
                 guard let data = Data(base64Encoded: attachment.data) else {
                     print("Error: Failed to decode attachment data.")

--- a/Tests/PostCLITests/AttachmentCommandTests.swift
+++ b/Tests/PostCLITests/AttachmentCommandTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import post
+
+final class AttachmentCommandTests: XCTestCase {
+    func testCIDSelectorParsesSuccessfully() throws {
+        let parsed = try PostCLI.Attachment.parse([
+            "14434",
+            "--cid", "C159B852-FFB2-4456-9D77-C4476E2E2D2C"
+        ])
+
+        XCTAssertEqual(parsed.uid, 14434)
+        XCTAssertEqual(parsed.cid, "C159B852-FFB2-4456-9D77-C4476E2E2D2C")
+        XCTAssertNil(parsed.filename)
+    }
+
+    func testFilenameAndCIDAreMutuallyExclusive() {
+        XCTAssertThrowsError(try PostCLI.Attachment.parse([
+            "14434",
+            "--filename", "invoice.pdf",
+            "--cid", "C159B852-FFB2-4456-9D77-C4476E2E2D2C"
+        ])) { error in
+            let message = PostCLI.Attachment.message(for: error)
+            XCTAssertTrue(message.contains("Use either --filename or --cid, not both."))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `post attachment --cid` for downloading CID-backed inline assets from messages
- normalize raw, `cid:...`, `<...>`, percent-encoded, and case-varied Content-ID values
- document the command and add CLI parse/validation tests

## Validation
- `swift test`
- manually downloaded the CID image from issue #22 (`image/png`, 1108 x 376)
