### PR TITLE
Use ProcessInfo.hostName for postd SSE log line

### DIFF
--- a/Sources/postd/PostDaemon.swift
+++ b/Sources/postd/PostDaemon.swift
@@ -129,7 +129,7 @@ extension PostDaemon {
                     let httpTransport = HTTPSSETransport(server: server, port: httpPort)
                     try await httpTransport.start()
                     transports.append(httpTransport)
-                    daemonLogger.info("MCP HTTP+SSE transport listening on http://\(String.localHostname):\(httpTransport.port)/sse")
+                    daemonLogger.info("MCP HTTP+SSE transport listening on http://\(ProcessInfo.processInfo.hostName):\(httpTransport.port)/sse")
                 }
 
                 try await tcpTransport.start()


### PR DESCRIPTION
## What

`postd`'s HTTP+SSE startup log built its URL with `String.localHostname`:

```swift
daemonLogger.info("MCP HTTP+SSE transport listening on http://\(String.localHostname):\(httpTransport.port)/sse")
```

SwiftMCP 1.5 (pulled in by [#25](https://github.com/Cocoanetics/Post/pull/25)) removed that helper. A Codex review on #25 flagged this as a P1 "won't compile" — but it was a **false positive**: the daemon kept building and CI stayed green, because **SwiftMail 1.6.4 still vends an identical `String.localHostname`** that leaks into `PostDaemon.swift` through `PostServer`'s transitive `import SwiftMail`. CI compiles every target (`swift build`, debug + release, macOS + Linux), so a real break there would have gone red.

So nothing was broken — but the green build leaned on two fragile things:

1. **SwiftMail keeping `localHostname`.** SwiftCross's own commit dropping it called it an "API smell inherited from SwiftMail/SwiftMCP," replacing it with the built-in `ProcessInfo.hostName` plus a new `ProcessInfo.localIPAddress`. SwiftMail's copy is a likely future removal.
2. **Leaky extension-member visibility** through a transitive import — which SE-0444 (`MemberImportVisibility`) would eventually turn into an error requiring a direct `import SwiftMail`.

## Change

Use Foundation's `ProcessInfo.processInfo.hostName` directly:

- **behavior-preserving** — the old helper returned `ProcessInfo.processInfo.hostName` first (IP/`localhost` only as fallbacks);
- **no new dependency** (Foundation is already imported; does *not* pull in SwiftCross, which intentionally has no hostname shim);
- **matches SwiftMCP's own convention** — `HTTPSSETransport.init` defaults its `host` to `ProcessInfo.processInfo.hostName`.

## Verification

- `swift build` ✅ — `post` + `postd` link cleanly against the pinned SwiftMCP 1.5.1 / SwiftMail 1.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
