### PR TITLE
Update all dependencies

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -31,7 +31,7 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
-    container: swift:6.1
+    container: swift:6.2
 
     steps:
       - uses: actions/checkout@v4

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "30f5ed1fe71f2bf239765cf08585b53323cbe491011cd328a3a07f69e737058b",
+  "originHash" : "fe9549770aeaf9964824a8ae86daff2422a74a63fffc94e024eb37f628725b4c",
   "pins" : [
+    {
+      "identity" : "jsonfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/JSONFoundation.git",
+      "state" : {
+        "revision" : "3ff56dbc893ec8addd33a46674c745873812c6cb",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
@@ -20,12 +38,21 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -33,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
+        "revision" : "eaa10d47d19919979dd8df22ff4fd6349b1108d4",
+        "version" : "1.19.2"
       }
     },
     {
@@ -74,12 +101,30 @@
       }
     },
     {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "92448c359f00ebe36ae97d3bd9086f13c7692b5a",
-        "version" : "1.13.2"
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
       }
     },
     {
@@ -94,19 +139,36 @@
     {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
+      "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "77b84ac2cd2ac9e4ac67d19f045fd5b434f56967",
-        "version" : "2.101.0"
+        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
+        "version" : "2.101.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
       }
     },
     {
       "identity" : "swift-nio-imap",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/odrobnik/swift-nio-imap",
+      "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "01de1f9a29df31f77e87c2d9248940de7233ee1e",
-        "version" : "0.3.0-pre"
+        "revision" : "bcf875610ca56dfd7bae869fa19ca3149c075908"
       }
     },
     {
@@ -114,8 +176,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
-        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e",
-        "version" : "2.37.1"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     },
     {
@@ -125,6 +195,24 @@
       "state" : {
         "revision" : "7d6d7531d40e95f4e1e26f6565265be6df228911",
         "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "11633673a41f509f8945f23c96c7acd4adafd679",
+        "version" : "0.5.0"
       }
     },
     {
@@ -159,8 +247,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMail",
       "state" : {
-        "revision" : "f5c09401c4bb9cb1a237d7a1c0990f7084190ada",
-        "version" : "1.6.4"
+        "revision" : "dbb1d0bb6bc7742249cf4800513c5562d54fa734"
       }
     },
     {
@@ -168,8 +255,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMCP",
       "state" : {
-        "revision" : "df3ef01ab09bcdf775f4669be242065e05d61feb",
-        "version" : "1.5.1"
+        "revision" : "7f120fed9e3d36f49aceb1b190e5289c69a6d623",
+        "version" : "1.9.0"
       }
     },
     {
@@ -177,8 +264,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftText",
       "state" : {
-        "revision" : "d095c12420826fe28e67fd1b3f6baa32e4606a80",
-        "version" : "1.1.9"
+        "branch" : "ec4dc821e00e80e4ddf81bfdaf42b72cc7d7235f",
+        "revision" : "f8e664269318e0fd2156a965a9e7dc3c4837a204"
+      }
+    },
+    {
+      "identity" : "xmlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/XMLKit.git",
+      "state" : {
+        "revision" : "92f0051ab9f2d570647b8b76f688b53bdfc1bf06",
+        "version" : "1.0.1"
       }
     },
     {
@@ -186,8 +282,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation.git",
       "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
+        "revision" : "187ee77287ea4b23df4d7de32771ec38bbafb840"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -21,11 +21,26 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.5.1")),
-        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.6.4")),
-        .package(url: "https://github.com/Cocoanetics/SwiftText", .upToNextMajor(from: "1.1.9")),
+        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.9.0")),
+        // Pinned to the 1.8.0 tag by revision: SwiftMail ≥ 1.7.0 depends on a
+        // revision-pinned swift-nio-imap (no upstream release yet), and SwiftPM
+        // refuses stable-version packages with unstable dependencies. Switch back
+        // to .upToNextMajor once SwiftMail depends on a tagged swift-nio-imap.
+        .package(url: "https://github.com/Cocoanetics/SwiftMail", revision: "dbb1d0bb6bc7742249cf4800513c5562d54fa734"),
+        // Pinned to the 2.0.0 tag by revision: SwiftText 2.0.0 depends on a
+        // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
+        // packages with unstable dependencies. Switch back to .upToNextMajor
+        // once SwiftText depends only on tagged releases.
+        .package(url: "https://github.com/Cocoanetics/SwiftText", revision: "ec4dc821e00e80e4ddf81bfdaf42b72cc7d7235f"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        // Not used directly: SwiftPM fails to resolve this trait-gated transitive
+        // dependency (via SwiftMCP → JSONFoundation) unless it is declared at the root.
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.5.0"),
+        // Not used directly: SwiftMail ≥ 1.7.0 pins swift-nio-imap to a revision
+        // (no upstream release yet), which SwiftPM only accepts when the root
+        // declares the same unstable dependency. Keep in sync with SwiftMail.
+        .package(url: "https://github.com/apple/swift-nio-imap", revision: "bcf875610ca56dfd7bae869fa19ca3149c075908")
     ],
     targets: [
         .plugin(


### PR DESCRIPTION
Brings all dependencies to their latest releases: **SwiftMCP 1.9.0**, **SwiftMail 1.8.0**, **SwiftText 2.0.0**, plus a refresh of transitive packages.

## Notable for Post

- **Sending**: calendar invites now go out inline per RFC 6047 (Accept/Decline UI in mail clients), non-ASCII headers are RFC 2047-encoded, attachment base64 uses proper CRLF line endings.
- **Reading**: fixes intermittently empty body parts when the IMAP server batches pipelined FETCH responses.
- **IMAP robustness**: IDLE connections only reused after verified teardown; concurrent named-connection auth coalesced.
- **MCP daemon**: SwiftMCP 1.6–1.9 — per-protocol-revision negotiation, decoupled transport lifecycle with ordered shutdown, SSE resume via JSONFoundation's stream hub.

## Packaging notes

- SwiftMail and SwiftText are pinned to the **exact commits of their release tags** (`1.8.0` / `2.0.0`): each depends on a revision-pinned package (apple/swift-nio-imap, ZIPFoundation), which SwiftPM refuses to resolve through a version requirement. Comments in Package.swift note when to switch back to `.upToNextMajor`.
- `swift-subprocess` is declared at the root as a workaround for a SwiftPM resolution failure on SwiftMCP's trait-gated transitive dependency (via JSONFoundation ≥ 2.4.0).

## Validation

- `swift build` (debug + release) clean
- `swift test` — 13 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)