### PR TITLE
Adopt the SwiftMCP 1.10.0 Bonjour discovery rework

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe9549770aeaf9964824a8ae86daff2422a74a63fffc94e024eb37f628725b4c",
+  "originHash" : "4fb01572df897f29c8ddfe6760f401436693855e47afb606d024cdc8e25f65bd",
   "pins" : [
     {
       "identity" : "jsonfoundation",
@@ -255,8 +255,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMCP",
       "state" : {
-        "revision" : "7f120fed9e3d36f49aceb1b190e5289c69a6d623",
-        "version" : "1.9.0"
+        "revision" : "79a527a4747190e5dc698ced1d96cfc51acda91f",
+        "version" : "1.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,10 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.9.0")),
+        // 1.10.0 reworked Bonjour discovery: serviceName: -> instanceName:, and
+        // DiscoveryScope replaces acceptLocalOnly. Source-breaking despite the
+        // minor bump, so the floor is 1.10.0 rather than 1.9.0.
+        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.0")),
         // Pinned to the 1.8.0 tag by revision: SwiftMail ≥ 1.7.0 depends on a
         // revision-pinned swift-nio-imap (no upstream release yet), and SwiftPM
         // refuses stable-version packages with unstable dependencies. Switch back

--- a/Sources/post/Commands/Idle.swift
+++ b/Sources/post/Commands/Idle.swift
@@ -11,7 +11,7 @@ extension PostCLI {
         var token: String?
 
         func run() async throws {
-            let tcpConfig = MCPServerTcpConfig(serviceName: PostProxy.serverName)
+            let tcpConfig = MCPServerTcpConfig(instanceName: PostProxy.serverName)
             let proxy = MCPServerProxy(config: .tcp(config: tcpConfig))
             if let token = ProcessInfo.processInfo.resolvedPostAPIToken() {
                 await proxy.setAccessTokenMeta(token)

--- a/Sources/post/PostProxy+WithClient.swift
+++ b/Sources/post/PostProxy+WithClient.swift
@@ -32,7 +32,7 @@ extension PostProxy {
             }
         }
 
-        let tcpConfig = MCPServerTcpConfig(serviceName: PostProxy.serverName)
+        let tcpConfig = MCPServerTcpConfig(instanceName: PostProxy.serverName)
         let proxy = MCPServerProxy(config: .tcp(config: tcpConfig))
         if let token = ProcessInfo.processInfo.resolvedPostAPIToken() {
             await proxy.setAccessTokenMeta(token)

--- a/Sources/postd/PostDaemon.swift
+++ b/Sources/postd/PostDaemon.swift
@@ -121,7 +121,7 @@ extension PostDaemon {
                 )
             }
 
-            let tcpTransport = TCPBonjourTransport(server: server, serviceName: PostServer.Client.serverName)
+            let tcpTransport = TCPBonjourTransport(server: server, instanceName: PostServer.Client.serverName)
             transports.append(tcpTransport)
 
             do {


### PR DESCRIPTION
Picks up [SwiftMCP 1.10.0](https://github.com/Cocoanetics/SwiftMCP/releases/tag/v1.10.0), which reworked Bonjour discovery.

## What changed here

Three call sites and one dependency floor:

```swift
// Sources/postd/PostDaemon.swift
TCPBonjourTransport(server: server, instanceName: PostServer.Client.serverName)
// Sources/post/PostProxy+WithClient.swift, Sources/post/Commands/Idle.swift
MCPServerTcpConfig(instanceName: PostProxy.serverName)
```

`postd` and `post` never passed a service type, domain, or `acceptLocalOnly`, so every knob that release removed was unused here. The new default scope is `.localUser`, which is what this daemon already meant: client and server are the same user on the same machine, and the CLI locates the daemon by deriving the same instance name the daemon registered.

The floor moves to `1.10.0` because that release is source-breaking despite the minor version — `1.9.0` would resolve and then fail to compile.

## Two things this fixes that Post could not fix on its own

**The daemon now genuinely binds loopback.** `acceptLocalOnly` restricted connections to the *directly attached link* — the LAN — not to localhost. `README.md:54` says the daemon accepts localhost connections only; it did not. Combined with MCP auth defaulting to off until an API key exists (`PostServer.swift:170`), a fresh install served the whole mailbox to any peer on the same network. It is now bound to loopback and registered local-only, so it is neither reachable nor visible off-box.

**Two accounts on one Mac no longer collide.** Instance names are machine-wide, so both users' daemons advertised `Post`, mDNS renamed the loser, and the second user's CLI could bind to the first user's daemon — the PID-file guard is `~/.post.pid`, which is per-user and does not fire. The name is now qualified by user, so each CLI derives its own.

To be precise about what that second fix is: it prevents *accidental mis-binding*, not access. A loopback socket is visible to every account on the machine, so another user can still connect deliberately. Post would need authentication for a real boundary — worth considering given the auth default.

## Testing

`swift build` and `swift test` clean. Bonjour discovery verified end to end against the tagged release.