### PR TITLE
Adopt SwiftMail 1.9.0 and drop the revision pins it forced

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4fb01572df897f29c8ddfe6760f401436693855e47afb606d024cdc8e25f65bd",
+  "originHash" : "071636494d9ee5d63e088be5e12fdf05314f01421e4d7b70d047123d3d1cb1e3",
   "pins" : [
     {
       "identity" : "jsonfoundation",
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "cd3e1152083706d77b223fb29110e590efcc70c0",
-        "version" : "2.101.2"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -168,7 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "bcf875610ca56dfd7bae869fa19ca3149c075908"
+        "revision" : "880366a41739a1a86d23b7857f533491b8a3cd07",
+        "version" : "0.3.0"
       }
     },
     {
@@ -176,7 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
-        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e"
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
       }
     },
     {
@@ -247,7 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMail",
       "state" : {
-        "revision" : "dbb1d0bb6bc7742249cf4800513c5562d54fa734"
+        "revision" : "7ba22114bf681acc105fe728d0130c79a6a51cf0",
+        "version" : "1.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,10 @@ let package = Package(
         // DiscoveryScope replaces acceptLocalOnly. Source-breaking despite the
         // minor bump, so the floor is 1.10.0 rather than 1.9.0.
         .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.0")),
-        // Pinned to the 1.8.0 tag by revision: SwiftMail ≥ 1.7.0 depends on a
-        // revision-pinned swift-nio-imap (no upstream release yet), and SwiftPM
-        // refuses stable-version packages with unstable dependencies. Switch back
-        // to .upToNextMajor once SwiftMail depends on a tagged swift-nio-imap.
-        .package(url: "https://github.com/Cocoanetics/SwiftMail", revision: "dbb1d0bb6bc7742249cf4800513c5562d54fa734"),
+        // 1.9.0 depends on a tagged swift-nio-imap (0.3.0) again, so SwiftMail is
+        // back on a version requirement — no revision pin, and no root
+        // swift-nio-imap declaration needed to satisfy SwiftPM.
+        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.0")),
         // Pinned to the 2.0.0 tag by revision: SwiftText 2.0.0 depends on a
         // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
         // packages with unstable dependencies. Switch back to .upToNextMajor
@@ -39,11 +38,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // Not used directly: SwiftPM fails to resolve this trait-gated transitive
         // dependency (via SwiftMCP → JSONFoundation) unless it is declared at the root.
-        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.5.0"),
-        // Not used directly: SwiftMail ≥ 1.7.0 pins swift-nio-imap to a revision
-        // (no upstream release yet), which SwiftPM only accepts when the root
-        // declares the same unstable dependency. Keep in sync with SwiftMail.
-        .package(url: "https://github.com/apple/swift-nio-imap", revision: "bcf875610ca56dfd7bae869fa19ca3149c075908")
+        .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "0.5.0")
     ],
     targets: [
         .plugin(


### PR DESCRIPTION
[SwiftMail 1.9.0](https://github.com/Cocoanetics/SwiftMail/releases/tag/1.9.0) depends on a tagged `swift-nio-imap` (0.3.0) again, which removes the constraint that made Post pin SwiftMail by revision. SwiftPM refuses a stable-version dependency whose own graph carries an unstable revision pin, and it only accepted the pinned SwiftMail when the root declared the same `swift-nio-imap` revision. Both workarounds are gone: SwiftMail is back on `.upToNextMajor(from: "1.9.0")`, and the root `swift-nio-imap` declaration is deleted. `swift-nio-ssl` and `swift-nio` come along as proper version pins (2.37.2, 2.101.3).

Three revision pins in `Package.resolved` become version pins as a result.

## Behavior changes

Both are inherited rather than configured here — Post constructs `IMAPServer`/`SMTPServer` with defaults.

- **TLS connections now floor at TLS 1.2.** They previously inherited NIOSSL's default of TLS 1.0, deprecated by [RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996) since March 2021, and the implicit-TLS path did not carry the configured floor at all. A mail server offering nothing above TLS 1.1 will now fail the handshake.
- **IMAP parser limits are enforced per connection.** Post keeps the permissive defaults, so what a server could send before it can still send; the machinery to bound it now exists.

## Notes

- `swift-nio-imap` stays at 0.3.0 rather than the newer 0.4.0 — 0.3.0 is what SwiftMail 1.9.0 was tested against, and nothing here needs 0.4.0 (its delta is RFC 9979 support and an internal ASCII-check refactor).
- SwiftText remains revision-pinned: it still depends on a revision-pinned ZIPFoundation.

## Validation

- `swift build` (debug + release), `swift test` — 13 tests, 0 failures
- SwiftMail 1.9.0's own suite: 356 tests in 49 suites, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)