### PR TITLE
Adopt SwiftMCP 1.10.1 and SwiftText 2.1.0, dropping the last revision pin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cfaf6eee0893f2604ef467f290ac8441b567957dec1c55d8d85c90a72884fde3",
+  "originHash" : "fbe72b988be379fdac581786146e340b41797577d898c71df297e1c334e107ed",
   "pins" : [
     {
       "identity" : "jsonfoundation",
@@ -267,8 +267,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftText",
       "state" : {
-        "revision" : "8093c0d3b22754bdbde895230f0f72dbfde6c69d",
-        "version" : "2.1.0"
+        "revision" : "8093c0d3b22754bdbde895230f0f72dbfde6c69d"
       }
     },
     {
@@ -278,6 +277,14 @@
       "state" : {
         "revision" : "92f0051ab9f2d570647b8b76f688b53bdfc1bf06",
         "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "zipfoundation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/weichsel/ZIPFoundation.git",
+      "state" : {
+        "revision" : "187ee77287ea4b23df4d7de32771ec38bbafb840"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "071636494d9ee5d63e088be5e12fdf05314f01421e4d7b70d047123d3d1cb1e3",
+  "originHash" : "cfaf6eee0893f2604ef467f290ac8441b567957dec1c55d8d85c90a72884fde3",
   "pins" : [
     {
       "identity" : "jsonfoundation",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/JSONFoundation.git",
       "state" : {
-        "revision" : "3ff56dbc893ec8addd33a46674c745873812c6cb",
-        "version" : "2.4.0"
+        "revision" : "4a147fbd0d655a8935e526f0865464e57580810f",
+        "version" : "2.5.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "eaa10d47d19919979dd8df22ff4fd6349b1108d4",
-        "version" : "1.19.2"
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version" : "1.34.1"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "880366a41739a1a86d23b7857f533491b8a3cd07",
-        "version" : "0.3.0"
+        "revision" : "d67f1243f731457cb9f2eb0beb27eff9e533bf7b",
+        "version" : "0.4.0"
       }
     },
     {
@@ -229,10 +229,10 @@
     {
       "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
+      "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMCP",
       "state" : {
-        "revision" : "79a527a4747190e5dc698ced1d96cfc51acda91f",
-        "version" : "1.10.0"
+        "revision" : "22ccdbf77d47d00377f9c8180c1a932589dc4bb3",
+        "version" : "1.10.1"
       }
     },
     {
@@ -267,8 +267,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftText",
       "state" : {
-        "branch" : "ec4dc821e00e80e4ddf81bfdaf42b72cc7d7235f",
-        "revision" : "f8e664269318e0fd2156a965a9e7dc3c4837a204"
+        "revision" : "8093c0d3b22754bdbde895230f0f72dbfde6c69d",
+        "version" : "2.1.0"
       }
     },
     {
@@ -278,14 +278,6 @@
       "state" : {
         "revision" : "92f0051ab9f2d570647b8b76f688b53bdfc1bf06",
         "version" : "1.0.1"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "187ee77287ea4b23df4d7de32771ec38bbafb840"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,19 +21,22 @@ let package = Package(
         )
     ],
     dependencies: [
-        // 1.10.0 reworked Bonjour discovery: serviceName: -> instanceName:, and
-        // DiscoveryScope replaces acceptLocalOnly. Source-breaking despite the
-        // minor bump, so the floor is 1.10.0 rather than 1.9.0.
-        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.0")),
+        // 1.10.1 fixes the TCP transport leaking one file descriptor per inbound
+        // connection (which wedged postd once its descriptor table filled, #30)
+        // and makes run() throw on unrecoverable listener failure instead of
+        // parking forever. The floor excludes 1.10.0 so no resolution can pick
+        // the leaking release again.
+        .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.1")),
         // 1.9.0 depends on a tagged swift-nio-imap (0.3.0) again, so SwiftMail is
         // back on a version requirement — no revision pin, and no root
         // swift-nio-imap declaration needed to satisfy SwiftPM.
         .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.0")),
-        // Pinned to the 2.0.0 tag by revision: SwiftText 2.0.0 depends on a
-        // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
-        // packages with unstable dependencies. Switch back to .upToNextMajor
-        // once SwiftText depends only on tagged releases.
-        .package(url: "https://github.com/Cocoanetics/SwiftText", revision: "ec4dc821e00e80e4ddf81bfdaf42b72cc7d7235f"),
+        // Only the HTML trait: Post uses just SwiftTextHTML/SwiftTextCore, and
+        // dropping the default CLI/DOCX/EPUB/PAGES traits prunes the
+        // revision-pinned ZIPFoundation from the graph — the dependency that
+        // previously forced this package to be revision-pinned too (SwiftPM
+        // refuses stable-version packages with unstable dependencies).
+        .package(url: "https://github.com/Cocoanetics/SwiftText", .upToNextMajor(from: "2.1.0"), traits: ["HTML"]),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // Not used directly: SwiftPM fails to resolve this trait-gated transitive

--- a/Package.swift
+++ b/Package.swift
@@ -31,12 +31,14 @@ let package = Package(
         // back on a version requirement — no revision pin, and no root
         // swift-nio-imap declaration needed to satisfy SwiftPM.
         .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.0")),
-        // Only the HTML trait: Post uses just SwiftTextHTML/SwiftTextCore, and
-        // dropping the default CLI/DOCX/EPUB/PAGES traits prunes the
-        // revision-pinned ZIPFoundation from the graph — the dependency that
-        // previously forced this package to be revision-pinned too (SwiftPM
-        // refuses stable-version packages with unstable dependencies).
-        .package(url: "https://github.com/Cocoanetics/SwiftText", .upToNextMajor(from: "2.1.0"), traits: ["HTML"]),
+        // Pinned to the 2.1.0 tag by revision: SwiftText still depends on a
+        // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
+        // packages with unstable dependencies. Swift 6.3 would accept a version
+        // requirement with traits: ["HTML"] (trait pruning drops ZIPFoundation
+        // before the check), but CI's Swift 6.2 checks before pruning. Switch
+        // back to .upToNextMajor once SwiftText depends only on tagged releases
+        // or CI moves to Swift 6.3.
+        .package(url: "https://github.com/Cocoanetics/SwiftText", revision: "8093c0d3b22754bdbde895230f0f72dbfde6c69d"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // Not used directly: SwiftPM fails to resolve this trait-gated transitive


### PR DESCRIPTION
[SwiftMCP 1.10.1](https://github.com/Cocoanetics/SwiftMCP/releases/tag/v1.10.1) is the fd-leak release that came out of the postd investigation in #30: the TCP+Bonjour transport dropped `NWConnection`s without `cancel()`, stranding one file descriptor per inbound MCP connection until the daemon's descriptor table filled and it wedged — still looking healthy from the outside. Beyond the leak, 1.10.1 reaps vanished peers via TCP keepalive within ~2 minutes, makes `notifications/cancelled` actually cancel the in-flight request, and tears down per-connection tasks with their connection.

Post picks all of that up with no code changes. The one call site touched by 1.10.1's behavior changes was already shaped for it: `tcpTransport.run()` sits in a `try await` inside a `do/catch` that stops transports, removes the PID file, and rethrows — so an unrecoverable listener failure now exits postd non-zero (launchd's `KeepAlive` restarts it) where SwiftMCP previously logged, swallowed, and served nothing forever. Post never switches exhaustively over `TransportError`, so the new `.resourceExhausted` case has no source impact. The floor moves to 1.10.1 so no resolution can pick the leaking 1.10.0 again.

[SwiftText 2.1.0](https://github.com/Cocoanetics/SwiftText/releases/tag/2.1.0) ships July's accumulated work (Markdown → EPUB 3 export, CSS Paged Media margin boxes, FlateDecode-compressed PDF output, Pages-extraction fidelity, the smart-punctuation reversal fix). The revision pin moves to the 2.1.0 tag's commit — SwiftText still depends on a revision-pinned ZIPFoundation, so the stable-version rule still bites.

A near-miss worth recording: declaring SwiftText with `.upToNextMajor(from: "2.1.0")` and `traits: ["HTML"]` resolves on Swift 6.3, whose SwiftPM prunes trait-disabled dependencies (ZIPFoundation among them) *before* the stable-version check — locally that built and tested green with ZIPFoundation gone from `Package.resolved` entirely. CI's Swift 6.2 runs the check before pruning and refuses. The manifest comment points at both exits: a SwiftText release on a tagged ZIPFoundation, or CI on Swift 6.3.

## Everything else `swift package update` picked up

- `swift-nio-imap` 0.3.0 → 0.4.0 — #29 deliberately held 0.3.0 as the graph SwiftMail 1.9.0 was tested against; a full update takes the float, and the delta (RFC 9979 support, an internal ASCII-check refactor) passes Post's suite.
- JSONFoundation 2.4.0 → 2.5.0, swift-certificates 1.19.2 → 1.19.4, swift-crypto 4.5.0 → 4.5.1, swift-nio-extras 1.34.1 → 1.34.3, swift-nio-http2 1.44.0 → 1.45.0, swift-system 1.7.2 → 1.7.5.

## Validation

- `swift build` (debug + release) and `swift test` — 13 tests, 0 failures
- SwiftText 2.1.0 was cut from a fully green main (macOS/iOS/Linux/Windows-CLI builds, Android/Windows portable tests, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)