### PR TITLE
Adopt SwiftMail 1.9.2 so IDLE teardown sticks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d6f3cd749f8009318b00c5d2a7030a38fdef08ba5badde6213a1850c9a286b82",
+  "originHash" : "faa70f75411588c9704c1b80cf6de423a5067fcc6b24713f63f1be329893d3ae",
   "pins" : [
     {
       "identity" : "jsonfoundation",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMail",
       "state" : {
-        "revision" : "43af3e7d5fd247ae91319dab055b3c7555c9386a",
-        "version" : "1.9.1"
+        "revision" : "ed4946b2051e4dce39755e280511ec0a37e737cf",
+        "version" : "1.9.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fbe72b988be379fdac581786146e340b41797577d898c71df297e1c334e107ed",
+  "originHash" : "d6f3cd749f8009318b00c5d2a7030a38fdef08ba5badde6213a1850c9a286b82",
   "pins" : [
     {
       "identity" : "jsonfoundation",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftMail",
       "state" : {
-        "revision" : "7ba22114bf681acc105fe728d0130c79a6a51cf0",
-        "version" : "1.9.0"
+        "revision" : "43af3e7d5fd247ae91319dab055b3c7555c9386a",
+        "version" : "1.9.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,13 +27,15 @@ let package = Package(
         // parking forever. The floor excludes 1.10.0 so no resolution can pick
         // the leaking release again.
         .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.1")),
-        // 1.9.1 makes IDLE teardown stick: before it, disconnect() only closed
-        // the dedicated IDLE connection's socket and the self-healing cycle task
-        // re-dialed the server, leaking the session's private EventLoopGroup
-        // (the IMAP-side share of #30). watchIdleEvents ends its producers with
-        // `try? await idleSession.done()` from already-cancelled tasks, which
-        // 1.9.1 pins as a tested contract. Floor excludes the leaking 1.9.0.
-        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.1")),
+        // 1.9.2 makes IDLE teardown stick: before 1.9.1, disconnect() only
+        // closed the dedicated IDLE connection's socket and the self-healing
+        // cycle task re-dialed the server, leaking the session's private
+        // EventLoopGroup (the IMAP-side share of #30); 1.9.2 also closes the
+        // post-cancellation reconnect window in that teardown. watchIdleEvents
+        // ends its producers with `try? await idleSession.done()` from
+        // already-cancelled tasks, which these releases pin as a tested
+        // contract. Floor excludes the leaking 1.9.0 and the racy 1.9.1.
+        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.2")),
         // Pinned to the 2.1.0 tag by revision: SwiftText still depends on a
         // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
         // packages with unstable dependencies. Swift 6.3 would accept a version

--- a/Package.swift
+++ b/Package.swift
@@ -27,10 +27,13 @@ let package = Package(
         // parking forever. The floor excludes 1.10.0 so no resolution can pick
         // the leaking release again.
         .package(url: "https://github.com/Cocoanetics/SwiftMCP", .upToNextMajor(from: "1.10.1")),
-        // 1.9.0 depends on a tagged swift-nio-imap (0.3.0) again, so SwiftMail is
-        // back on a version requirement — no revision pin, and no root
-        // swift-nio-imap declaration needed to satisfy SwiftPM.
-        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.0")),
+        // 1.9.1 makes IDLE teardown stick: before it, disconnect() only closed
+        // the dedicated IDLE connection's socket and the self-healing cycle task
+        // re-dialed the server, leaking the session's private EventLoopGroup
+        // (the IMAP-side share of #30). watchIdleEvents ends its producers with
+        // `try? await idleSession.done()` from already-cancelled tasks, which
+        // 1.9.1 pins as a tested contract. Floor excludes the leaking 1.9.0.
+        .package(url: "https://github.com/Cocoanetics/SwiftMail", .upToNextMajor(from: "1.9.1")),
         // Pinned to the 2.1.0 tag by revision: SwiftText still depends on a
         // revision-pinned ZIPFoundation, and SwiftPM refuses stable-version
         // packages with unstable dependencies. Swift 6.3 would accept a version


### PR DESCRIPTION
[SwiftMail 1.9.2](https://github.com/Cocoanetics/SwiftMail/releases/tag/1.9.2) (with [1.9.1](https://github.com/Cocoanetics/SwiftMail/releases/tag/1.9.1) under it) is the IMAP-side share of #30: `IMAPServer.disconnect()` used to close only the dedicated IDLE connection's socket, and the self-healing cycle task treated that as a dropped connection and re-dialed — the session survived disconnect and its private 1-thread `EventLoopGroup` (thread + kqueue/pipe descriptors) leaked every time (Cocoanetics/SwiftMail#196). Review on that fix found one more window — a reconnect already in flight when the cancellation lands completes dial + auth and leaves a live socket — closed in 1.9.2 (Cocoanetics/SwiftMail#197), which also force-closes anything a dying runner leaves behind.

Post picks it up with **no code changes**, and this is the notable part: the earlier read of `watchIdleEvents` suspected Post's producer cleanup (`try? await idleSession.done()` running on an already-cancelled task) swallowed the teardown. It does not — SwiftMail's teardown is internally shielded, and 1.9.1+ pins exactly that as a tested contract (`doneFromCancelledTaskStillTearsDownSession`): `done()` from a cancelled task completes the full sequence — cycle task cancelled, connection closed, EventLoopGroup shut down, events stream finished. [IdleEventStreams.swift](Sources/PostServer/IdleEventStreams.swift) is correct as written.

With this bump, all three legs of #30 are addressed:

1. **MCP-side fd leak + zombie listener** — SwiftMCP 1.10.1 (#31, already on main)
2. **IMAP-side IDLE teardown re-dial + EventLoopGroup leak, including the post-cancellation reconnect race** — SwiftMail 1.9.2 (this PR)
3. **Post's watch/producer code** — verified correct; covered by SwiftMail's contract tests

The floor moves to 1.9.2 so no resolution can pick the leaking 1.9.0 or the racy 1.9.1 again.

## Validation

- `swift build` (debug + release) and `swift test` — 13 tests, 0 failures
- SwiftMail 1.9.2's suite: 358 tests in 49 suites, 0 failures, including the teardown regression tests (verified to fail against pre-fix sources) now also asserting the fake server's accepted-connection count stays flat across teardown
- Resolved-graph delta is exactly one entry: SwiftMail 1.9.0 → 1.9.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)